### PR TITLE
lock openai version

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "microsoft-cognitiveservices-speech-sdk": "^1.41.0",
     "nanoid": "^5.0.9",
     "nth-check": "^2.1.1",
-    "openai": "^4.73.1",
+    "openai": "4.73.1",
     "path-browserify": "^1.0.1",
     "path-to-regexp": "^8.2.0",
     "postcss": "^8.4.49",

--- a/src/pages/ConsolePageAssistant.tsx
+++ b/src/pages/ConsolePageAssistant.tsx
@@ -97,27 +97,27 @@ export function ConsolePageAssistant() {
 
   const cleanupVectorStores = async () => {
     try {
-      const bectorStoresPages: VectorStore[] = [];
+      const vectorStoresPages: VectorStore[] = [];
       let lists: VectorStoresPage =
         await getOpenAIClient().beta.vectorStores.list();
 
-      bectorStoresPages.push(...lists.data);
+      vectorStoresPages.push(...lists.data);
       setConnectMessage(
-        `Collecting Vector Stores(${bectorStoresPages.length})...`,
+        `Collecting Vector Stores(${vectorStoresPages.length})...`,
       );
 
       while (lists.hasNextPage()) {
         lists = await lists.getNextPage();
-        bectorStoresPages.push(...lists.data);
+        vectorStoresPages.push(...lists.data);
         setConnectMessage(
-          `Collecting Vector Stores(${bectorStoresPages.length})...`,
+          `Collecting Vector Stores(${vectorStoresPages.length})...`,
         );
       }
 
-      for (const [index, vectorStore] of bectorStoresPages.entries()) {
+      for (const [index, vectorStore] of vectorStoresPages.entries()) {
         if (vectorStore.name === APP_AGENT_VECTOR_STORE) {
           setConnectMessage(
-            `Deleting Vector Store(${index}/${bectorStoresPages.length}): ${vectorStore.id}`,
+            `Deleting Vector Store(${index}/${vectorStoresPages.length}): ${vectorStore.id}`,
           );
           await getOpenAIClient().beta.vectorStores.del(vectorStore.id);
         }


### PR DESCRIPTION
## Summary by Sourcery

Fix variable naming in ConsolePageAssistant.tsx and lock OpenAI package version in package.json.

Bug Fixes:
- Correct variable name from 'bectorStoresPages' to 'vectorStoresPages' in ConsolePageAssistant.tsx.

Build:
- Lock OpenAI package version to 4.73.1 in package.json.