### PR TITLE
improved setting input

### DIFF
--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -26,6 +26,7 @@ const Dropdown: React.FC<DropdownProps> = ({
     borderRadius: 3,
     backgroundColor: isNightMode ? 'rgba(0, 0, 0, 0.8)' : 'rgba(0, 0, 0, 0.1)',
     color: isNightMode ? '#ffffff' : '#000000',
+    height: '35px',
   };
 
   const optionStyle: React.CSSProperties = {

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -175,6 +175,7 @@ const SettingsComponent: React.FC<{
       border: '0px solid #ccc',
       borderRadius: '4px',
       width: '100%',
+      height: '35px',
       fontSize: '12px',
       margin: '0',
       backgroundColor: isNightMode

--- a/src/pages/LocalStorageViewer.tsx
+++ b/src/pages/LocalStorageViewer.tsx
@@ -210,12 +210,6 @@ const LocalStorageViewer: React.FC = () => {
                   <td className={styles.tdKey}>llmInstructions</td>
                   <td className={styles.tdValue}>{llmInstructions}</td>
                 </tr>
-                <tr key="functionsToolsRef">
-                  <td className={styles.tdKey}>functionsToolsRef</td>
-                  <td className={styles.tdValue}>
-                    {JSON.stringify(functionsToolsRef.current, null, 2)}
-                  </td>
-                </tr>
               </tbody>
             </table>
 


### PR DESCRIPTION
## Summary by Sourcery

Standardize the height of input fields and dropdown components to 35px for a more consistent look and feel. Remove the functionsToolsRef from the LocalStorageViewer.

Enhancements:
- Standardize the height of input fields and dropdown components to 35px.
- Remove the functionsToolsRef from the LocalStorageViewer.