### PR TITLE
eslint-disable-next-line 

### DIFF
--- a/src/components/OpenAITTS.tsx
+++ b/src/components/OpenAITTS.tsx
@@ -43,6 +43,7 @@ const OpenAITTS: React.FC = () => {
     sentencesRef.current = sentences;
   }, [sentences]);
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const fetchAudioStream = async (text: string) => {
     setIsCreating(true);
     console.log('isCreating', text);

--- a/src/components/OpenAITTS.tsx
+++ b/src/components/OpenAITTS.tsx
@@ -107,7 +107,7 @@ const OpenAITTS: React.FC = () => {
     return () => {
       clearInterval(intervalId);
     };
-  }, []);
+  }, [avatarStatusRef, fetchAudioStream, needSpeechQueueRef]);
 
   useEffect(() => {
     const intervalId = setInterval(() => {
@@ -141,7 +141,7 @@ const OpenAITTS: React.FC = () => {
     return () => {
       clearInterval(intervalId);
     };
-  }, []);
+  }, [avatarStatusRef, setCaption]);
 
   return null;
 };


### PR DESCRIPTION
## Summary by Sourcery

Fix React hook dependency warnings by adding missing dependencies to useEffect hooks and suppressing an exception for the fetchAudioStream function.

Enhancements:
- Add eslint-disable-next-line comment to suppress exhaustive-deps warning for fetchAudioStream.
- Include avatarStatusRef, fetchAudioStream, and needSpeechQueueRef in the first useEffect dependency array.
- Include avatarStatusRef and setCaption in the second useEffect dependency array.