### PR TITLE
resort tts options

### DIFF
--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -117,8 +117,8 @@ const deepSeekFunctionCallingTypes = [
 ];
 
 const speechMethodOptions = [
-  { value: SPEECH_METHOD_STREAM, label: 'Stream' },
   { value: SPEECH_METHOD_COMPLETION, label: 'Completion' },
+  { value: SPEECH_METHOD_STREAM, label: 'Stream' },
 ];
 
 const useAgentProxyOptions = [

--- a/src/lib/const.tsx
+++ b/src/lib/const.tsx
@@ -119,7 +119,7 @@ export const speechLanguageMapMan: Record<string, string> = {
 
 export const SPEECH_METHOD_STREAM = 'Stream';
 export const SPEECH_METHOD_COMPLETION = 'Completion';
-export const SPEECH_METHOD_DEFAULT = SPEECH_METHOD_STREAM;
+export const SPEECH_METHOD_DEFAULT = SPEECH_METHOD_COMPLETION;
 
 export const DEEPSEEK_FUNCTION_CALL_ENABLE = 'Enable';
 export const DEEPSEEK_FUNCTION_CALL_DISABLE = 'Disable';


### PR DESCRIPTION
## Summary by Sourcery

Reorder the TTS speech method options in the settings UI and switch the default method to “Completion” instead of “Stream”.

Enhancements:
- Move “Stream” option below “Completion” in the speech method dropdown.
- Update default speech method constant from Stream to Completion.